### PR TITLE
Update script prompts to match actual defaults

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ function preflight_checks {
     echo "[PRE-CHECK] Ready to install plugin."
 
     local install_answer
-    read < /dev/tty -rp "[PRE-CHECK] Do you want to continue? [Y/n] " install_answer
+    read < /dev/tty -rp "[PRE-CHECK] Do you want to continue? [y/N] " install_answer
     if [[ -z "$install_answer" ]]; then
         install_answer="n"
     fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -27,7 +27,7 @@ function preflight_checks {
     echo "[PRE-CHECK] Ready to uninstall plugin."
 
     local uninstall_answer
-    read < /dev/tty -rp "[PRE-CHECK] Do you want to continue? [Y/n] " uninstall_answer
+    read < /dev/tty -rp "[PRE-CHECK] Do you want to continue? [y/N] " uninstall_answer
     if [[ -z "$uninstall_answer" ]]; then
         uninstall_answer="n"
     fi


### PR DESCRIPTION
The script prompt shows that yes is the default option for both install and uninstall, but script defaults to no. This change corrects the prompts to show the correct defaults.