### PR TITLE
Update install.sh - create default filter data directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,8 @@ function install_plugin {
     chmod +x ${GIT_PATH}/install.sh
     chmod +x ${GIT_PATH}/uninstall.sh
 
+    mkdir ~/printer_data/config/plugins/filter_monitor
+
     echo "OK!"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -74,7 +74,9 @@ function install_plugin {
     chmod +x ${GIT_PATH}/install.sh
     chmod +x ${GIT_PATH}/uninstall.sh
 
-    mkdir ~/printer_data/config/plugins/filter_monitor
+if [ ! -d "${HOME}/printer_data/config/plugins/filter_monitor" ]; then
+  mkdir -p "${HOME}/printer_data/config/plugins/filter_monitor"
+fi
 
     echo "OK!"
 }


### PR DESCRIPTION
Great plugin, thanks. Following installation I received an error that the folder where filter data is stored didn't exist. Suggest adding mkdir to installation script - or add mkdir step to instructions.